### PR TITLE
Add managementURL to CustomerPurchasesInfo and expose getManagementUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.5] - 2025-07-30
+## [0.0.5] - 2025-08-28
+
+### Added
+
+- `managementURL`.
 
 ### Updated
 

--- a/lib/src/core/helper/customer_purchase_info_helper.dart
+++ b/lib/src/core/helper/customer_purchase_info_helper.dart
@@ -27,6 +27,7 @@ class CustomerPurchaseInfoHelper {
           customerInfo.latestExpirationDate != null ? DateTime.tryParse(customerInfo.latestExpirationDate!) : null,
       purchases: subs,
       originalAppUserId: customerInfo.originalAppUserId,
+      managementURL: customerInfo.managementURL,
     );
   }
 }

--- a/lib/src/core/model/customer_purchases_info.dart
+++ b/lib/src/core/model/customer_purchases_info.dart
@@ -14,12 +14,15 @@ class CustomerPurchasesInfo {
   /// The original App User ID (e.g. RevenueCat's appUserId)
   final String originalAppUserId;
 
-  CustomerPurchasesInfo({
+  final String? managementURL;
+
+  const CustomerPurchasesInfo({
     required this.hasActiveSubscription,
     this.originalPurchaseDate,
     this.latestExpirationDate,
     this.purchases = const [],
     required this.originalAppUserId,
+    required this.managementURL,
   });
 
   @override
@@ -31,6 +34,7 @@ class CustomerPurchasesInfo {
         '  latestExpirationDate: $latestExpirationDate,\n'
         '  purchases: $purchasesStr,\n'
         '  originalAppUserId: $originalAppUserId\n'
+        '  managementURL: $managementURL\n'
         ')';
   }
 }

--- a/lib/src/core/service/purchases_service.dart
+++ b/lib/src/core/service/purchases_service.dart
@@ -29,5 +29,7 @@ abstract class PurchasesService {
 
   Future<Result<CustomerPurchasesInfo>> getCustomerPurchasesInfo();
 
+  Future<Result<String?>> getManagementUrl();
+
   Stream<CustomerPurchasesInfo> get customerPurchasesInfoStream;
 }

--- a/lib/src/services/revenuecat_service.dart
+++ b/lib/src/services/revenuecat_service.dart
@@ -224,4 +224,12 @@ class RevenueCatService extends PurchasesService {
       },
     ).mapErrorAsync((error) => PurchaseMethodException('getCustomerPurchasesInfo', originalError: error.originalError));
   }
+
+  @override
+  Future<Result<String?>> getManagementUrl() async {
+    return resultOfAsync(() async {
+      final CustomerInfo customerInfo = await Purchases.getCustomerInfo();
+      return customerInfo.managementURL;
+    }).mapErrorAsync((error) => PurchaseMethodException('getManagementUrl', originalError: error.originalError));
+  }
 }

--- a/lib/src/tangent_sdk.dart
+++ b/lib/src/tangent_sdk.dart
@@ -315,7 +315,7 @@ class TangentSDK {
 
   Future<Result<CustomerPurchasesInfo>> restorePurchases() async {
     return await _revenueService?.restorePurchases() ??
-        Success(CustomerPurchasesInfo(hasActiveSubscription: false, originalAppUserId: '', purchases: []));
+        Success(CustomerPurchasesInfo(hasActiveSubscription: false, originalAppUserId: '', purchases: [], managementURL: null));
   }
 
   Future<Result<List<Product>>> getOffering(String offeringId) async {
@@ -328,6 +328,10 @@ class TangentSDK {
 
   Stream<CustomerPurchasesInfo> get customerPurchasesInfoStream =>
       _revenueService?.customerPurchasesInfoStream ?? const Stream.empty();
+
+  Future<Result<String?>> getManagementUrl() async {
+    return await _revenueService?.getManagementUrl() ?? const Success(null);
+  }
 
   /// Determines if the given `productId` is a renewal purchase based on the
   /// existing purchase history.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tangent_sdk
 description: "A comprehensive SDK wrapper for Firebase, Mixpanel, Adjust, and RevenueCat with unified analytics and crash reporting."
-version: 0.0.4
+version: 0.0.5
 homepage:
 
 environment:


### PR DESCRIPTION
- Add managementURL field to CustomerPurchasesInfo model and helper
- Update PurchasesService and RevenueCatService to provide getManagementUrl()
- Update TangentSDK to expose getManagementUrl method
- Update CHANGELOG and handle managementURL in restorePurchases
- Prepares SDK for easier access to subscription management URLs