### PR TITLE
Set _isInitialized to true immediately after Superwall config

### DIFF
--- a/lib/src/services/superwall_service.dart
+++ b/lib/src/services/superwall_service.dart
@@ -45,6 +45,7 @@ class SuperwallService extends PaywallsService {
           AppLogger.info('Superwall configuration completed', tag: superwallTag);
         },
       );
+      _isInitialized = true;
 
       // 2) Identify with the SAME id as RevenueCat
       await identifyUser(revenueCarUserId);
@@ -56,9 +57,7 @@ class SuperwallService extends PaywallsService {
         AppLogger.info('Superwall subscription status: $status', tag: superwallTag);
       });
 
-      _isInitialized = true;
       AppLogger.info('Superwall initialized successfully', tag: superwallTag);
-
       return const Success(null);
     } catch (e, stackTrace) {
       AppLogger.error('Failed to initialize Superwall', error: e, stackTrace: stackTrace, tag: superwallTag);


### PR DESCRIPTION
Move _isInitialized assignment to immediately after Superwall configuration to ensure accurate initialization state before user identification and subscription status checks. This improves reliability of initialization flow.