### PR TITLE
Add config flag to control App Tracking Transparency initialization

### DIFF
--- a/lib/src/core/model/tangent_config.dart
+++ b/lib/src/core/model/tangent_config.dart
@@ -18,6 +18,11 @@ class TangentConfig {
   final String? superwallIOSApiKey;
   final String? superwallAndroidApiKey;
 
+  /// Controls whether App Tracking Transparency (ATT) service is initialized.
+  /// When enabled, the SDK will automatically initialize the ATT service on iOS
+  /// Defaults to `true`.
+  final bool enableAppTrackingTransparency;
+
   const TangentConfig({
     this.mixpanelToken,
     this.adjustAppToken,
@@ -33,5 +38,6 @@ class TangentConfig {
     this.enableSuperwall = true,
     this.superwallIOSApiKey,
     this.superwallAndroidApiKey,
+    this.enableAppTrackingTransparency = true,
   });
 }

--- a/lib/src/services/superwall_service.dart
+++ b/lib/src/services/superwall_service.dart
@@ -7,7 +7,7 @@ import 'package:tangent_sdk/src/core/types/result.dart';
 import 'package:tangent_sdk/src/core/utils/app_logger.dart';
 import 'package:tangent_sdk/src/services/rc_purchase_controller.dart';
 
-const superwallTag = "Superwall";
+const superwallTag = "Superwall💸";
 
 class SuperwallService extends PaywallsService {
   final String iOSApiKey;

--- a/lib/src/tangent_sdk.dart
+++ b/lib/src/tangent_sdk.dart
@@ -143,10 +143,12 @@ class TangentSDK {
     }
 
     // Initialize app tracking transparency
-    AppLogger.info('Initializing App Tracking Transparency Service', tag: 'Tracking');
-    _appTrackingTransparency = AppTrackingTransparencyService();
-    await _appTrackingTransparency!.init();
-    AppLogger.info('App Tracking Transparency Service initialized', tag: 'Tracking');
+    if (_config.enableAppTrackingTransparency) {
+      AppLogger.info('Initializing App Tracking Transparency Service', tag: 'Tracking');
+      _appTrackingTransparency = AppTrackingTransparencyService();
+      await _appTrackingTransparency!.init();
+      AppLogger.info('App Tracking Transparency Service initialized', tag: 'Tracking');
+    }
 
     // Initialize app review service (utility - always available)
     AppLogger.info('Initializing App Review Service', tag: 'Review');
@@ -433,6 +435,7 @@ class TangentSDK {
 
   // App Tracking Transparency Methods
   Future<void> requestTrackingAuthorization() async {
+    _appTrackingTransparency ??= AppTrackingTransparencyService();
     await _appTrackingTransparency?.init();
   }
 


### PR DESCRIPTION
- Introduce enableAppTrackingTransparency to TangentConfig to allow toggling ATT service initialization, defaulting to true
- Update TangentSDK to conditionally initialize ATT service based on this flag
- Clarify ATT service documentation in config
- Update Superwall log tag for clarity